### PR TITLE
(branch pull request) Add certificate profile selection for HSM CA import

### DIFF
--- a/modules/ejbca-ejb-cli/src/org/ejbca/ui/cli/ca/CaImportCACommand.java
+++ b/modules/ejbca-ejb-cli/src/org/ejbca/ui/cli/ca/CaImportCACommand.java
@@ -68,6 +68,7 @@ public class CaImportCACommand extends BaseCaAdminCommand {
     private static final String CA_TOKEN_PASSWORD_KEY = "--ctpassword";
     private static final String CA_TOKEN_PROPERTIES_FILE_KEY = "--prop";
     private static final String CA_CERTIFICATE_FILE_KEY = "--cert";
+    private static final String CERTIFICATE_PROFILE_KEY = "--certificateprofile";
 
     {
         registerParameter(new Parameter(HARD_SWITCH_KEY, "", MandatoryMode.OPTIONAL, StandaloneMode.FORBID, ParameterMode.FLAG,
@@ -100,6 +101,13 @@ public class CaImportCACommand extends BaseCaAdminCommand {
                 StandaloneMode.ALLOW,
                 ParameterMode.ARGUMENT,
                 "(PKCS#11) A file containing CA-certificates. One or more CA-certificates, with this CA's certificate first, and others following in certificate chain order."));
+        registerParameter(new Parameter(
+                CERTIFICATE_PROFILE_KEY,
+                "Certificate Profile Name",
+                MandatoryMode.OPTIONAL,
+                StandaloneMode.ALLOW,
+                ParameterMode.ARGUMENT,
+                "(PKCS#11) Optional certificate profile to use for the imported CA. If not specified, ROOTCA or SUBCA will be automatically selected based on the certificate chain."));
 
     }
 
@@ -207,6 +215,15 @@ public class CaImportCACommand extends BaseCaAdminCommand {
                 log.error("No such file: " + parameters.get(CA_TOKEN_PROPERTIES_FILE_KEY));
                 return CommandResult.FUNCTIONAL_FAILURE;
             }
+            
+            // Handle certificate profile parameter
+            String certificateProfile = parameters.get(CERTIFICATE_PROFILE_KEY);
+            if (certificateProfile != null && !certificateProfile.trim().isEmpty()) {
+                // Append certificate profile to properties for passing through to the import method
+                catokenproperties = catokenproperties + "\ncertificateProfileName=" + certificateProfile.trim();
+                log.info("Using certificate profile: " + certificateProfile);
+            }
+            
             Collection<Certificate> cacerts;
             try {
                 cacerts = CertTools.getCertsFromPEM(parameters.get(CA_CERTIFICATE_FILE_KEY), Certificate.class);
@@ -256,7 +273,9 @@ public class CaImportCACommand extends BaseCaAdminCommand {
                 + " PKCS#12 keystore is the default option, while CA certificate can be chosen by specifying the flag " + HARD_SWITCH_KEY + " to import a CA certificate where the keys are on an HSM.\n"
                 + "The two usages are: \n" + "<CA name> <pkcs12 file> [" + KEYSTORE_PASSWORD_KEY
                 + " <password>] [<signature alias>] [<encryption alias>]\n" + "    or:\n" + "<CA name> " + HARD_SWITCH_KEY
-                + " <catokenclasspath> <catokenpassword> <catokenproperties> <ca-certificate-file>";
+                + " <catokenclasspath> <catokenpassword> <catokenproperties> <ca-certificate-file> [" + CERTIFICATE_PROFILE_KEY + " <certificate profile name>]"
+                + "\n\nFor PKCS#11 (HSM) imports, the optional " + CERTIFICATE_PROFILE_KEY + " parameter can be used to specify a custom certificate profile. "
+                + "If not specified, ROOTCA or SUBCA will be automatically selected based on the certificate chain.";
     }
     
     @Override

--- a/modules/ejbca-ejb/src/org/ejbca/core/ejb/ca/caadmin/CAAdminSessionBean.java
+++ b/modules/ejbca-ejb/src/org/ejbca/core/ejb/ca/caadmin/CAAdminSessionBean.java
@@ -2797,7 +2797,7 @@ public class CAAdminSessionBean implements CAAdminSessionLocal, CAAdminSessionRe
             keySpecification = "2048";
         }
         // Do the general import
-        CA ca = importCA(authenticationToken, caname, keystorepass, signatureCertChain, catoken, keyAlgorithm, keySpecification);
+        CA ca = importCA(authenticationToken, caname, keystorepass, signatureCertChain, catoken, keyAlgorithm, keySpecification, null);
         // Finally audit log
         logAuditEvent(
                 EjbcaEventTypes.CA_IMPORT, EventStatus.SUCCESS,
@@ -2913,6 +2913,24 @@ public class CAAdminSessionBean implements CAAdminSessionLocal, CAAdminSessionRe
         Certificate cacert = signatureCertChain[0];
         int caId = StringTools.strip(CertTools.getSubjectDN(cacert)).hashCode();
         Properties caTokenProperties = CAToken.getPropertiesFromString(catokenproperties);
+        
+        // Extract certificate profile if specified in properties
+        Integer certificateProfileId = null;
+        String certificateProfileName = caTokenProperties.getProperty("certificateProfileName");
+        if (certificateProfileName != null && !certificateProfileName.trim().isEmpty()) {
+            // Remove from properties so it doesn't interfere with crypto token configuration
+            caTokenProperties.remove("certificateProfileName");
+            
+            // Look up the certificate profile ID
+            certificateProfileId = certificateProfileSession.getCertificateProfileId(certificateProfileName.trim());
+            if (certificateProfileId == null || certificateProfileId == 0) {
+                log.warn("Certificate profile '" + certificateProfileName + "' not found. Using default profile selection.");
+                certificateProfileId = null; // Reset to null to use default logic
+            } else {
+                log.info("Using certificate profile '" + certificateProfileName + "' (ID: " + certificateProfileId + ") for imported CA");
+            }
+        }
+        
         // Create the CryptoToken
         int cryptoTokenId = createCryptoTokenWithUniqueName(authenticationToken, "ImportedCryptoToken" + caId, PKCS11CryptoToken.class.getName(),
                 caTokenProperties, null, catokenpassword.toCharArray());
@@ -2947,7 +2965,7 @@ public class CAAdminSessionBean implements CAAdminSessionLocal, CAAdminSessionRe
             keySpecification = "2048";
         }
         // Do the general import
-        importCA(authenticationToken, caname, catokenpassword, signatureCertChain, catoken, keyAlgorithm, keySpecification);
+        importCA(authenticationToken, caname, catokenpassword, signatureCertChain, catoken, keyAlgorithm, keySpecification, certificateProfileId);
     }
 
     /**
@@ -2982,6 +3000,7 @@ public class CAAdminSessionBean implements CAAdminSessionLocal, CAAdminSessionRe
     /**
      * @param keyAlgorithm     keyalgorithm for extended CA services, OCSP, CMS. Example AlgorithmConstants.KEYALGORITHM_RSA
      * @param keySpecification keyspecification for extended CA services, OCSP, CMS. Example 2048
+     * @param certificateProfileId optional certificate profile ID to use for the imported CA. If null, defaults to ROOTCA or SUBCA based on certificate type
      * @throws AuthorizationDeniedException             if imported CA was signed by a CA user does not have authorization to.
      * @throws CAExistsException                        if the CA already exists
      * @throws CAOfflineException                       if CRLs can not be generated because imported CA did not manage to get online
@@ -2990,7 +3009,7 @@ public class CAAdminSessionBean implements CAAdminSessionLocal, CAAdminSessionRe
      * @throws CryptoTokenOfflineException              if crypto token is unavailable.
      */
     private CA importCA(AuthenticationToken admin, String caname, String keystorepass, Certificate[] signatureCertChain, CAToken catoken,
-                        String keyAlgorithm, String keySpecification) throws CryptoTokenAuthenticationFailedException, CryptoTokenOfflineException,
+                        String keyAlgorithm, String keySpecification, Integer certificateProfileId) throws CryptoTokenAuthenticationFailedException, CryptoTokenOfflineException,
             IllegalCryptoTokenException, AuthorizationDeniedException, CAExistsException, CAOfflineException {
         // Create a new CA
         int signedby = CAInfo.SIGNEDBYEXTERNALCA;
@@ -2999,6 +3018,8 @@ public class CAAdminSessionBean implements CAAdminSessionLocal, CAAdminSessionRe
         Certificate caSignatureCertificate = signatureCertChain[0];
         ArrayList<Certificate> certificatechain = new ArrayList<>();
         Collections.addAll(certificatechain, signatureCertChain);
+        
+        // Determine if CA is self-signed and set defaults
         if (signatureCertChain.length == 1) {
             if (verifyIssuer(caSignatureCertificate, caSignatureCertificate)) {
                 signedby = CAInfo.SELFSIGNED;
@@ -3047,6 +3068,12 @@ public class CAAdminSessionBean implements CAAdminSessionLocal, CAAdminSessionRe
                     }
                 }
             }
+        }
+        
+        // Override certificate profile if specified
+        if (certificateProfileId != null && certificateProfileId > 0) {
+            certprof = certificateProfileId;
+            log.info("Using specified certificate profile ID: " + certprof + " for imported CA: " + caname);
         }
 
         CAInfo cainfo = null;


### PR DESCRIPTION
This patch adds the ability to specify a custom certificate profile when importing a CA from an HSM using the --certificateprofile parameter.

Changes:
- Added optional --certificateprofile parameter to CaImportCACommand
- Modified importCAFromHSM to extract and validate certificate profile
- Updated importCA method to use specified profile instead of hardcoded defaults
- Maintains full backward compatibility when parameter is not specified

Implementation approach:
- Uses existing catokenproperties to pass the profile name (minimal footprint)
- No interface changes required (only 2 files modified)
- Graceful fallback to default behavior if profile doesn't exist
- Profile is removed from properties before crypto token initialization

Usage:
ejbca.sh ca importca MyCA --hard ... --certificateprofile MyCustomProfile

When not specified, the existing behavior is preserved:
- ROOTCA profile for self-signed certificates
- SUBCA profile for externally signed certificates

🤖 Generated with Claude Code