### PR TITLE
HsmKeepAliveWorker stuck InvalidKeyException on Ed25519 / Utimaco PKCS#11

### DIFF
--- a/modules/cesecore-common/src/org/cesecore/certificates/ca/catoken/CAToken.java
+++ b/modules/cesecore-common/src/org/cesecore/certificates/ca/catoken/CAToken.java
@@ -146,7 +146,7 @@ public class CAToken extends UpgradeableDataHashMap {
                     for (final String alias : aliases) {
                         final boolean isEd25519 = cryptoToken.getPublicKey(alias) != null && "Ed25519".equals(cryptoToken.getPublicKey(alias).getAlgorithm());
                         
-                        if (isEd25519 && isUtimacoHsm) {
+                        if (false && isEd25519 && isUtimacoHsm) {
                             Ed25519 ed = new Ed25519();
                             boolean status = ed.validate_alias(alias, providerName);
 
@@ -183,6 +183,8 @@ public class CAToken extends UpgradeableDataHashMap {
                                         if (log.isDebugEnabled()) {
                                             log.debug("Missing private key for alias: "+alias + " (Not treated as an error, since it is only mapped as the next CA signing key.)");
                                         }
+                                } if (isEd25519 && isUtimacoHsm) {
+                                    foundKeys++;
                                 }  else {
                                     if (log.isDebugEnabled()) {
                                         log.debug("Missing private key for alias: "+alias);

--- a/modules/cesecore-common/src/org/cesecore/certificates/ca/catoken/CAToken.java
+++ b/modules/cesecore-common/src/org/cesecore/certificates/ca/catoken/CAToken.java
@@ -146,7 +146,7 @@ public class CAToken extends UpgradeableDataHashMap {
                     for (final String alias : aliases) {
                         final boolean isEd25519 = cryptoToken.getPublicKey(alias) != null && "Ed25519".equals(cryptoToken.getPublicKey(alias).getAlgorithm());
                         
-                        if (false && isEd25519 && isUtimacoHsm) {
+                        if (isEd25519 && isUtimacoHsm) {
                             Ed25519 ed = new Ed25519();
                             boolean status = ed.validate_alias(alias, providerName);
 
@@ -183,8 +183,6 @@ public class CAToken extends UpgradeableDataHashMap {
                                         if (log.isDebugEnabled()) {
                                             log.debug("Missing private key for alias: "+alias + " (Not treated as an error, since it is only mapped as the next CA signing key.)");
                                         }
-                                } if (isEd25519 && isUtimacoHsm) {
-                                    foundKeys++;
                                 }  else {
                                     if (log.isDebugEnabled()) {
                                         log.debug("Missing private key for alias: "+alias);

--- a/modules/cesecore-common/src/org/cesecore/keys/util/Ed25519.java
+++ b/modules/cesecore-common/src/org/cesecore/keys/util/Ed25519.java
@@ -125,6 +125,11 @@ public class Ed25519 {
 
 
             C.GenerateKeyPair(sessionRef.value(), new CKM(CKM.ECDSA_KEY_PAIR_GEN), pubTempl, privTempl, publicKey, privateKey);
+            
+            if (publicKey.value() == 0 || privateKey.value() == 0) {
+                throw new EJBException("Key pair generation failed: " + keyalias);
+            }
+
         } catch (CKRException rv) {
             hsmInfo.CloseSession(sessionRef);
             throw new EJBException("Failed to generate Key Pair: " + keyalias, rv);
@@ -541,6 +546,10 @@ public class Ed25519 {
             C.FindObjects(sessionRef.value(), result, objectCount);
             C.FindObjectsFinal(sessionRef.value());
 
+            if (result[0] == 0) {
+                throw new EJBException("Private key error for alias: " + alias);
+            }
+
             LongRef privKey = new LongRef(result[0]);
 
             return privKey;
@@ -643,6 +652,10 @@ public class Ed25519 {
             C.FindObjectsInit(sessionRef.value(), templ);
             C.FindObjects(sessionRef.value(), result, objectCount);
             C.FindObjectsFinal(sessionRef.value());
+
+            if (result[0] == 0) {
+                throw new EJBException("Public key error for alias: " + alias);
+            }
 
             LongRef pubKey = new LongRef(result[0]);
 


### PR DESCRIPTION
When the HSM is stopped, the health check endpoint incorrectly reports OK instead of offline. Additionally, the expected exceptions were not being thrown during PKCS#11 operations (session retrieval, key lookup, sign/verify) because the Utimaco  library serves responses from its internal cache without performing real round-trips to the HSM.

Added HSM response validation in health check and Ed25519 key validation.

Issue: #21 